### PR TITLE
Improve chat

### DIFF
--- a/src/components/chat/Messages.tsx
+++ b/src/components/chat/Messages.tsx
@@ -100,7 +100,7 @@ export default function Messages() {
 }
 
 const Container = tw.div`
-  absolute flex w-full h-full overflow-y-scroll
+  absolute flex w-full h-full overflow-x-clip overflow-y-scroll break-words
 `;
 
 const List = tw.ol`

--- a/src/components/chat/Messages.tsx
+++ b/src/components/chat/Messages.tsx
@@ -100,7 +100,7 @@ export default function Messages() {
 }
 
 const Container = tw.div`
-  absolute flex w-full h-full overflow-x-clip overflow-y-scroll break-words
+  absolute flex w-full h-full overflow-x-clip overflow-y-scroll break-words whitespace-pre-wrap
 `;
 
 const List = tw.ol`

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -97,7 +97,7 @@ export default function TextArea() {
 
           <TextInput
             ref={inputRef}
-            type="text"
+            contenteditable="true"
             placeholder={`Message #${channel.name}`}
           />
 
@@ -160,8 +160,8 @@ const FileInput = tw.input`
   file:w-full file:h-full file:bg-transparent file:border-0
 `;
 
-const TextInput = tw.input`
-  py-2.5 w-full h-full bg-transparent font-medium placeholder-gray-500 text-gray-800 outline-0 outline-hidden
+const TextInput = tw.div`
+  py-2.5 w-full h-full bg-transparent font-medium placeholder-gray-500 text-gray-800 outline-0 outline-hidden break-words
   focus:outline-0 focus:outline-hidden
 `;
 

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -18,7 +18,7 @@ export default function TextArea() {
   const [messageImage, setMessageImage] = useState<File>();
   const dispatch = useAppDispatch();
 
-  function handleInput(e: any) {
+  function handleKeyDown(e: KeyboardEvent) {
     if (e.key === "Enter" && e.shiftKey === false) {
       e.preventDefault();
       sendMessage();
@@ -106,7 +106,7 @@ export default function TextArea() {
           <TextInput
             ref={inputRef}
             contentEditable
-            onKeyDown={handleInput}
+            onKeyDown={handleKeyDown}
             placeholder={`Message #${channel.name}`}
           />
 

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -97,7 +97,7 @@ export default function TextArea() {
 
           <TextInput
             ref={inputRef}
-            contenteditable="true"
+            contentEditable
             placeholder={`Message #${channel.name}`}
           />
 

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -162,6 +162,7 @@ const FileInput = tw.input`
 
 const TextInput = tw.div`
   py-2.5 w-full h-full bg-transparent font-medium placeholder-gray-500 text-gray-800 outline-0 outline-hidden break-words
+  empty:before:content-[attr(placeholder)] empty:before:text-[#5E6772]
   focus:outline-0 focus:outline-hidden
 `;
 

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -33,7 +33,7 @@ export default function TextArea() {
     )
       return "";
 
-    const messageContent = inputRef.current.textContent;
+    const messageContent = inputRef.current.textContent.trim();
 
     inputRef.current.textContent = "";
 

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -161,7 +161,7 @@ const FileInput = tw.input`
 `;
 
 const TextInput = tw.div`
-  py-2.5 w-full h-full bg-transparent font-medium placeholder-gray-500 text-gray-800 outline-0 outline-hidden break-words
+  py-2.5 w-full h-full bg-transparent font-medium text-gray-800 outline-0 outline-hidden break-all
   empty:before:content-[attr(placeholder)] empty:before:text-[#5E6772]
   focus:outline-0 focus:outline-hidden
 `;

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -19,7 +19,7 @@ export default function TextArea() {
   const dispatch = useAppDispatch();
 
   function handleInput(e: any) {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && e.shiftKey === false) {
       e.preventDefault();
       sendMessage();
       return;
@@ -170,9 +170,9 @@ const FileInput = tw.input`
 `;
 
 const TextInput = tw.div`
-  py-2.5 w-full h-full bg-transparent font-medium text-gray-800 outline-0 outline-hidden break-all
-  empty:before:content-[attr(placeholder)] empty:before:text-[#5E6772]
+  py-2.5 w-full h-full bg-transparent font-medium text-gray-800 outline-0 outline-hidden break-all whitespace-pre-wrap
   focus:outline-0 focus:outline-hidden
+  empty:before:content-[attr(placeholder)] empty:before:text-[#5E6772]
 `;
 
 const GifButtonContainer = tw.div`

--- a/src/components/chat/textArea/TextArea.tsx
+++ b/src/components/chat/textArea/TextArea.tsx
@@ -10,7 +10,7 @@ import { useAppDispatch } from "../../../redux/hooks";
 import { setSendGifOpen, useSendGifState } from "../../../features/sendGif";
 
 export default function TextArea() {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLDivElement>(null);
   const { server, channel } = useServersState();
   const { user } = useUserState();
   const { sendGifOpen } = useSendGifState();
@@ -18,21 +18,29 @@ export default function TextArea() {
   const [messageImage, setMessageImage] = useState<File>();
   const dispatch = useAppDispatch();
 
+  function handleInput(e: any) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      sendMessage();
+      return;
+    }
+  }
+
   function getText() {
-    if (!inputRef.current || inputRef.current.value.trim() === "") return "";
+    if (
+      !inputRef.current?.textContent ||
+      inputRef.current.textContent.trim() === ""
+    )
+      return "";
 
-    let messageContent;
+    const messageContent = inputRef.current.textContent;
 
-    messageContent = inputRef.current.value;
-
-    inputRef.current.value = "";
+    inputRef.current.textContent = "";
 
     return messageContent;
   }
 
-  async function sendMessage(e: React.FormEvent) {
-    e.preventDefault();
-
+  async function sendMessage() {
     const content = getText();
 
     if (!content && !messageImageURL) return;
@@ -89,7 +97,7 @@ export default function TextArea() {
           </>
         )}
 
-        <FormContainer onSubmit={sendMessage}>
+        <FormContainer>
           <AttachButtonContainer>
             <AttachButton src={uploadImageIcon} width={24} height={24} />
             <FileInput type="file" onChange={uploadImage} />
@@ -98,6 +106,7 @@ export default function TextArea() {
           <TextInput
             ref={inputRef}
             contentEditable
+            onKeyDown={handleInput}
             placeholder={`Message #${channel.name}`}
           />
 

--- a/src/utilities/functions.tsx
+++ b/src/utilities/functions.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { setChannel, useServersState } from "../features/servers";
 import { useAppDispatch } from "../redux/hooks";
 
-export function parseURLs(message: string) {
+export function parseURLs(message: string, link = true) {
   if (
     !message ||
     (!message.includes("https://") && !message.includes("http://"))
@@ -19,12 +19,14 @@ export function parseURLs(message: string) {
       {fixedArray.map((message, index) => {
         return index % 2 === 0 ? (
           <span key={index}>{message}</span>
-        ) : (
+        ) : link ? (
           <Link href={message} passHref key={index}>
             <LinkText rel="noreferrer noopener" target="_blank">
               {message}
             </LinkText>
           </Link>
+        ) : (
+          <DummyLinkText>{message}</DummyLinkText>
         );
       })}
     </>
@@ -41,7 +43,7 @@ function addSlash(messageArray: string[]) {
   });
 }
 
-export function useParseLinks(message: string) {
+export function useParseLinks(message: string, link = true) {
   const { channels } = useServersState();
   const dispatch = useAppDispatch();
 
@@ -57,11 +59,17 @@ export function useParseLinks(message: string) {
         );
 
         return match ? (
-          <Link href={match.path} passHref key={index}>
-            <ChannelLinkText onClick={() => dispatch(setChannel(match))}>
-              {parseURLs(message)}
-            </ChannelLinkText>
-          </Link>
+          link ? (
+            <Link href={match.path} passHref key={index}>
+              <ChannelLinkText onClick={() => dispatch(setChannel(match))}>
+                {parseURLs(message, link)}
+              </ChannelLinkText>
+            </Link>
+          ) : (
+            <DummyChannelLinkText>
+              {parseURLs(message, link)}
+            </DummyChannelLinkText>
+          )
         ) : (
           <span key={index}>{parseURLs(message)}</span>
         );
@@ -77,4 +85,13 @@ const LinkText = tw.a`
 
 const ChannelLinkText = tw.a`
   text-channel-link bg-channel-link-background/[0.15] rounded-[3px] px-0.5 cursor-pointer
-  hover:text-white hover:bg-channel-link-background/100`;
+  hover:text-white hover:bg-channel-link-background/100
+`;
+
+const DummyLinkText = tw.span`
+  text-url-link
+`;
+
+const DummyChannelLinkText = tw.span`
+  text-channel-link bg-channel-link-background/[0.15] rounded-[3px] px-0.5 cursor-pointer
+`;


### PR DESCRIPTION
## Changes
* Change `<TextInput />` to `div` element with `contentEditable` set to `true`.
    * Along with `break-words`, this allows overflowing messages to create a line break rather than continue to pass through the right side of the screen.
* Prevent chat from scrolling on x-axis (helpful for small screens/windows).
* Allow multiline messages with `SHIFT` + `ENTER`.
    * Preserve whitespace in messages.

## In progress

* Automatically convert detected URLs in text area to clickable `<a />` tags

## Issues
* Will close #42.