### PR TITLE
Improve linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "banter",
-  "version": "0.1.2-alpha",
+  "version": "0.1.3-alpha",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/utilities/functions.tsx
+++ b/src/utilities/functions.tsx
@@ -4,12 +4,6 @@ import { setChannel, useServersState } from "../features/servers";
 import { useAppDispatch } from "../redux/hooks";
 
 export function parseURLs(message: string, link = true) {
-  if (
-    !message ||
-    (!message.includes("https://") && !message.includes("http://"))
-  )
-    return message;
-
   const messageArray = message.split(/(https?:\/\/\w[^ ]+)/);
 
   const fixedArray = addSlash(messageArray);
@@ -47,10 +41,13 @@ export function useParseLinks(message: string, link = true) {
   const { channels } = useServersState();
   const dispatch = useAppDispatch();
 
+  if (message && (message.includes("https://") || message.includes("http://")))
+    return parseURLs(message);
+
   return findChannels(message);
 
   function findChannels(message: string) {
-    if (!message || !message.includes("#")) return parseURLs(message);
+    if (!message || !message.includes("#")) return message;
 
     const messageArray = message.split(/(#\w[^ ]+)/);
 
@@ -73,12 +70,10 @@ export function useParseLinks(message: string, link = true) {
                 </>
               </Link>
             ) : (
-              <DummyChannelLinkText>
-                {parseURLs(message, link)}
-              </DummyChannelLinkText>
+              <DummyChannelLinkText>{message}</DummyChannelLinkText>
             )
           ) : (
-            <span key={index}>{parseURLs(message)}</span>
+            <span key={index}>{message}</span>
           );
         })}
       </>

--- a/src/utilities/functions.tsx
+++ b/src/utilities/functions.tsx
@@ -47,35 +47,43 @@ export function useParseLinks(message: string, link = true) {
   const { channels } = useServersState();
   const dispatch = useAppDispatch();
 
-  if (!message || !message.includes("#")) return parseURLs(message);
+  return findChannels(message);
 
-  const messageArray = message.split(/(#\w[^ ]+)/);
+  function findChannels(message: string) {
+    if (!message || !message.includes("#")) return parseURLs(message);
 
-  return (
-    <>
-      {messageArray.map((message, index) => {
-        const match = channels.find(
-          (channel) => message.substring(1) === channel.name
-        );
+    const messageArray = message.split(/(#\w[^ ]+)/);
 
-        return match ? (
-          link ? (
-            <Link href={match.path} passHref key={index}>
-              <ChannelLinkText onClick={() => dispatch(setChannel(match))}>
+    return (
+      <>
+        {messageArray.map((message, index) => {
+          const match = channels.find((channel) =>
+            message.includes(channel.name)
+          );
+
+          return match ? (
+            link ? (
+              <Link href={match.path} passHref key={index}>
+                <>
+                  {findChannels(message.split(match.name)[0].slice(0, -1))}
+                  <ChannelLinkText onClick={() => dispatch(setChannel(match))}>
+                    #{match.name}
+                  </ChannelLinkText>
+                  {findChannels(message.split(match.name)[1])}
+                </>
+              </Link>
+            ) : (
+              <DummyChannelLinkText>
                 {parseURLs(message, link)}
-              </ChannelLinkText>
-            </Link>
+              </DummyChannelLinkText>
+            )
           ) : (
-            <DummyChannelLinkText>
-              {parseURLs(message, link)}
-            </DummyChannelLinkText>
-          )
-        ) : (
-          <span key={index}>{parseURLs(message)}</span>
-        );
-      })}
-    </>
-  );
+            <span key={index}>{parseURLs(message)}</span>
+          );
+        })}
+      </>
+    );
+  }
 }
 
 const LinkText = tw.a`


### PR DESCRIPTION
## Changes

* Improve `useParseLinks` functionality
    * Now properly detects linked channels before a newline
* Improve link detection functionality of `parseURLs` hook
    * Now properly links the entire URL, even if part of it resembles a channel link
        * (e.g. https://www.website.com/about#general)
* Refactor code
* Bump `version` to `0.1.3-alpha`